### PR TITLE
Fix for error on second 'disable'

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"qlab-advance"
 	],
-	"version": "1.1.7",
+	"version": "1.1.8",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"qlab-advance"
 	],
-	"version": "1.1.6",
+	"version": "1.1.7",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",


### PR DESCRIPTION
When adding a 'disable' instance action on a button, it is possible to disable a module twice in a row.
The second time throws an error on already deleted objects.