### PR TITLE
Prevent improper cue variable removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"qlab-advance"
 	],
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",


### PR DESCRIPTION
Sometimes, deleted cue detection removes valid cues when changing cuelists.
Rapid changing of cuelists, deleting cues, workspace resets can still result in cue variables being removed internally.