### PR TITLE
Add transport/feedback/variables by unique ID

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -2,9 +2,10 @@
 
 What does QLab do?
 QLab makes it simple to create intricate designs of light, sound, and video, which you play back during a live performance.
-QLab allows you to lock in exactly how you want the light, sound, and video to play during your performance. When you’re done designing, you'll switch to “show mode” and run your show just by pressing “GO”.
+QLab allows you to lock in exactly how you want the light, sound, and video to play during your performance. When you are done designing, switch to “show mode” and run your show just by pressing “GO”.
 
-Go over to [figure 53](https://figure53.com/) and checkout the software.
+The software is available at [QLab.app](qlab.app). You can use QLab for 2 channel audio and 1 screen video without
+needing a license.
 
 This module adds a TCP mode option to the *QLab* module.
 Due to the nature and volume of information feedback and variables are only available in TCP mode.
@@ -28,6 +29,7 @@ Action | Description
 **Go** | Tell the current cue list of the given workspace to GO.
 **Stop** | Stop playback but allow effects to continue rendering. e.g., playback stops, but reverbs decay naturally.
 **Panic** | Tell the workspace to panic. A panic is a brief gradual fade out leading into a hard stop. A double panic will trigger an immediate hard stop.
+**Panic In Time** | Tell the workspace to panic over time specified.
 **Reset** | Reset the workspace. Resetting stops all cues, returns the playhead to the top of the current cue list, and restores any temporary changes made to cues (such as retargeting via a Target cue or adjustments using a "live" OSC method.)
 **Next** | Move the selection down one cue.
 **Previous** | Move the selection up one cue.
@@ -35,10 +37,14 @@ Action | Description
 **Resume** | Un-pause all paused cues in the workspace.
 **Preview** | Preview the selected cue without moving the Playhead.
 **Toggle Pause** | Pause/Unpause selected cue
-**GoTo (cue)** | Move the playhead to (cue). Doesn't start the cue.
-**Start (cue)** | Start (cue). Doesn't move the playhead. If the specified cue is playing, this command has no effect.
+**GoTo (Cue/ID)** | Move the playhead to (Cue/ID). Does not start the cue.
+**Start (Cue/ID)** | Start (Cue/ID). Does not move the playhead. If the specified cue is playing, this command has no effect.
+**Stop (Cue/ID)** | Stops (Cue/ID) if Playing. Does not move the playhead.
+**Panic (Cue/ID)** | Panic (Cue/ID) if Playing. Does not move the playhead.
+**Panic (Cue/ID) In Time** | Panic (Cue/ID) over time specified if Playing. Does not move the playhead.
 **Show Mode** | Enable for Show Mode, Disable for Edit Mode.
 **Audition Window** | Show or Hide the Audition Window.
+**Override Window** | Show or Hide the Override Controls Window.
 **Master Override** | Set Master override for Midi, MSC, SysEx, OSC, Timecode, Art-Net On or Off
 **Set Minimum Go** | Sets the time for double-GO protection
 **Increase Prewait** | Increases the prewait time by given time for the selected cue.
@@ -57,10 +63,12 @@ Action | Description
 **Set/Unset Autoload** | Set / Unset the Autoload property of the selected cue.
 **Set Continue Mode** | Sets the continue mode of the selected cue.
 **Set Cue Color** | Sets the color of the selected cue.
+**Copy Unique Cue ID** | Copies the Unique ID of the cue at the Playhead to actions and feedbacks.
+The next action or feedback inserted will have the Unique ID already filled in.
 
 There are presets included for most of these actions.\
 Show Mode, Audition Window, Arm, and Autoload actions also have a Toggle option to invert the current setting of the cue.\
-For additional actions please raise a feature request at [github](https://github.com/bitfocus/companion-module-qlab-advance/issues)\
+For additional actions please raise a feature request at [github](https://github.com/bitfocus/companion-module-qlab-advance/issues)
 
 ## Variables available (TCP mode only)
 Variable | Description
@@ -81,6 +89,7 @@ Variable | Description
 **$(INSTANCENAME:r_ss)** | Seconds left for Running Cue
 **$(INSTANCENAME:r_left)** | Shortest display time left for Running Cue. Shows .1 increments if tenths option set.
 **$(INSTANCENAME:q_{num}_name)** | Name of the QLab cue number {num}. See below for certain restrictions.
+**$(INSTANCENAME:id_{ID}_name)** | Name of the QLab cue ID {ID}. See below for certain restrictions.
 **$(INSTANCENAME:min_go)** | Current value of double-go protection (in seconds)
 
 To use these, replace INSTANCENAME with the name of your module instance.
@@ -91,16 +100,18 @@ Feedback | Description
 **Playhead Cue Color as Background** | Sets the button backgound to QLab color of the current playhead cue
 **Running Cue Color as Background** | Sets the button background to QLab color of the currently running cue
 **Cue Number Color as Background** | Sets the button background to QLab color of a specified cue
-**Colors for Workspace Mode** | Set the button color for QLab workspace modes: Audition (window on), Show Mode, Edit Mode
 **Colors for GO status** | Set the button color for the GO button state: active or disabled via the double-go timer
-**Colors for Master Override** | Set the button colors if the selected Override is Active (Turned off)
-**Colors when Cue # is Running** | Set the button colors when a specific cue is running
+**Indicate Workspace Mode** | Set the button to indicate the QLab workspace mode: Audition (window on), Show Mode, Edit Mode
+**Indicate Override Window On** | Set the button to indicate Override Window is Visible
+**Indicate Master Override** | Set the button to indicate if the selected Override is Active (Turned off)
+**Show Cue # is Running** | Set the button to show when a specific cue is running
+**Show Cue ID is Running** | Set the button to show when a specific cue ID is running
 
 ## OSC
 This module connects to QLab on port 53000.
 
-From Qlab preferences OSC controls tab make sure you have the "Use OSC controls" checkbox ticked.
-![Qlab](images/qlab.jpg?raw=true "Qlab")
+From QLab preferences OSC controls tab make sure you have the "Use OSC controls" checkbox ticked.
+![QLab](images/qlab.jpg?raw=true "QLab")
 
 ### Running cue examples
  QLab can run many cues at the same time while Stream Deck has a limited number of buttons visible at once. So which *one* cue is the most useful to show on a button? This module looks for the most recently run (GO) cue and favors *run all at once* Group cues over other types of cues.
@@ -109,5 +120,8 @@ From Qlab preferences OSC controls tab make sure you have the "Use OSC controls"
 - Now add 2 more screens with more images. Each transition (1 image for each screen) is now placed in a *run all* Group cue for list management. After the 5 group cues are run, QLab will show 20 cues active, 5 slides for each screen plus the 5 group cues. The last 'GO' **Group** cue will be the 'Running' cue.
 - If the last 'GO' Group cue is *enter then run each*, the most recent 'GO' cue in the group will be the 'Running' cue.
 
-### Cue Numbers
-QLab allows almost any characters in a Cue Number. Some characters don't play well with OSC or Companion. Using '$', '(', or ')' in your Cue Number won't work if you want to use the q_{cue}_name variable or the 'q_bg' feedback.
+### Cue Numbers / IDs
+QLab allows almost any characters in a Cue Number. Some characters don't play well with OSC or Companion. Using '$', '(', or ')' in your Cue Number won't work if you want to use the `q_{num}_name` variable or the `q_bg` feedback.\
+Transport actions, variables, and feedbacks have an ID version that uses the QLab Unique Cue ID as the target instead of the Cue Number. QLab does not show this internal ID so there is a special action **Copy Unique Cue ID** that will temporarily insert the ID of the playhead/selected cue into the ID style actions. \
+The examples and descriptions use {num} as a place marker for the Cue or ID to use.\
+Do not enter the braces {}: To refer to Cue #10 you would enter `q_10_name`.

--- a/actions.js
+++ b/actions.js
@@ -12,27 +12,124 @@ module.exports = {
 			'resume':           { label: 'Resume' },
 			'togglePause':		{ label: 'Toggle Pause'},
 			'stopSelected':     { label: 'Stop selected' },
-			'panic':            { label: 'Panic' },
+			'panic':            { label: 'Panic (ALL)' },
+			'panicInTime': {
+				label: 'Panic (ALL) In Time',
+				options: [{
+					type: 'textinput',
+					label: 'Time in Seconds',
+					id: 'time',
+					regex: this.REGEX_FLOAT,
+					default: 0
+				}],
+			},
 			'reset':            { label: 'Reset' },
 			'load':             { label: 'Load Cue' },
 			'preview':          { label: 'Preview'},
-			'start': {
-				label: 'Start (cue)',
-				options: [{
-					type: 'textinput',
-					label: 'Cue',
-					id: 'cue',
-					default: "1"
-				}]
-			},
 			'goto': {
 				label: 'Go To (cue)',
 				options: [{
 					type: 'textinput',
 					label: 'Cue',
 					id: 'cue',
-					default: "1"
+					default: '1',
+					default: this.nextCue.qNumber
 				}]
+			},
+			'start': {
+				label: 'Start (cue)',
+				options: [{
+					type: 'textinput',
+					label: 'Cue',
+					id: 'cue',
+					default: '1'
+				}]
+			},
+			'stop_cue': {
+				label: 'Stop (cue)',
+				options: [{
+					type: 'textinput',
+					label: 'Cue',
+					id: 'cue',
+					default: '1',
+				}, ],
+			},
+			'panic_cue': {
+				label: 'Panic (Cue)',
+				options: [{
+					type: 'textinput',
+					label: 'Cue',
+					id: 'cue',
+				}, ],
+			},
+			'panicInTime_cue': {
+				label: 'Panic (Cue) In Time',
+				options: [{
+						type: 'textinput',
+						label: 'Cue',
+						id: 'cue',
+					},
+					{
+						type: 'textinput',
+						label: 'Time in Seconds',
+						id: 'time',
+						regex: this.REGEX_FLOAT,
+						default: 0
+					},
+				],
+			},
+			'goto_id': {
+				label: 'Goto (Cue ID)',
+				options: [{
+					type: 'textinput',
+					label: 'Cue ID',
+					id: 'cueId',
+					default: this.nextCue
+				}, ],
+			},
+			'start_id': {
+				label: 'Start (Cue ID)',
+				options: [{
+					type: 'textinput',
+					label: 'Cue ID',
+					id: 'cueId',
+					default: this.nextCue
+				}, ],
+			},
+			'stop_id': {
+				label: 'Stop (Cue ID)',
+				options: [{
+					type: 'textinput',
+					label: 'Cue ID',
+					id: 'cueId',
+					default: this.nextCue
+				}, ],
+			},
+			'panic_id': {
+				label: 'Panic (Cue ID)',
+				options: [{
+					type: 'textinput',
+					label: 'Cue ID',
+					id: 'cueId',
+					default: this.nextCue
+				}, ],
+			},
+			'panicInTime_id': {
+				label: 'Panic (Cue ID) In Time',
+				options: [{
+						type: 'textinput',
+						label: 'Cue ID',
+						id: 'cueId',
+						default: this.nextCue
+					},
+					{
+						type: 'textinput',
+						label: 'Time in Seconds',
+						id: 'time',
+						regex: this.REGEX_FLOAT,
+						default: 0
+					},
+				],
 			},
 			'showMode': {
 				label: 'Show mode',
@@ -54,6 +151,16 @@ module.exports = {
 					choices: this.choices.TOGGLE
 				}]
 			},
+			'overrideWindow': {
+				label: 'Override Controls Window',
+				options: [{
+					type: 	'dropdown',
+					label: 	'Mode',
+					id:		'onOff',
+					default: 1,
+					choices: this.choices.TOGGLE
+				}]
+			},
 			'overrides': {
 				label: 'Master Override',
 				options: [
@@ -61,6 +168,7 @@ module.exports = {
 					type:	'dropdown',
 					label:	'Override',
 					id:		'which',
+					default: this.choices.OVERRIDE[0].id,
 					choices: this.choices.OVERRIDE
 				},
 				{
@@ -79,7 +187,7 @@ module.exports = {
 					label: 'Time in Seconds',
 					id: 'time',
 					regex: this.REGEX_FLOAT,
-					default: "0"
+					default: 0
 				}]
 			},
 			'prewait_dec': {
@@ -89,7 +197,7 @@ module.exports = {
 					label: 'Time in seconds',
 					id: 'time',
 					regex: this.REGEX_FLOAT,
-					default: "1"
+					default: 1
 				}]
 			},
 			'prewait_inc': {
@@ -99,7 +207,7 @@ module.exports = {
 					label: 'Time in seconds',
 					id: 'time',
 					regex: this.REGEX_FLOAT,
-					default: "1"
+					default: 1
 				}]
 			},
 			'postwait_dec': {
@@ -109,7 +217,7 @@ module.exports = {
 					label: 'Time in seconds',
 					id: 'time',
 					regex: this.REGEX_FLOAT,
-					default: "1"
+					default: 1
 				}]
 			},
 			'postwait_inc': {
@@ -119,7 +227,7 @@ module.exports = {
 					label: 'Time in seconds',
 					id: 'time',
 					regex: this.REGEX_FLOAT,
-					default: "1"
+					default: 1
 				}]
 			},
 			'duration_dec': {
@@ -129,7 +237,7 @@ module.exports = {
 					label: 'Time in seconds',
 					id: 'time',
 					regex: this.REGEX_FLOAT,
-					default: "1"
+					default: 1
 				}]
 			},
 			'duration_inc': {
@@ -139,7 +247,7 @@ module.exports = {
 					label: 'Time in seconds',
 					id: 'time',
 					regex: this.REGEX_FLOAT,
-					default: "1"
+					default: 1
 				}]
 			},
 			'startTime_dec': {
@@ -149,7 +257,7 @@ module.exports = {
 					label: 'Time in seconds',
 					id: 'time',
 					regex: this.REGEX_FLOAT,
-					default: "1"
+					default: 1
 				}]
 			},
 			'startTime_inc': {
@@ -159,7 +267,7 @@ module.exports = {
 					label: 'Time in seconds',
 					id: 'time',
 					regex: this.REGEX_FLOAT,
-					default: "1"
+					default: 1
 				}]
 			},
 			'endTime_dec': {
@@ -169,7 +277,7 @@ module.exports = {
 					label: 'Time in seconds',
 					id: 'time',
 					regex: this.REGEX_FLOAT,
-					default: "1"
+					default: 1
 				}]
 			},
 			'endTime_inc': {
@@ -179,7 +287,7 @@ module.exports = {
 					label: 'Time in seconds',
 					id: 'time',
 					regex: this.REGEX_FLOAT,
-					default: "1"
+					default: 1
 				}]
 			},
 			'continue': {
@@ -249,6 +357,9 @@ module.exports = {
 					default: 1,
 					choices: this.choices.TOGGLE
 				}]
+			},
+			'copyCueID': {
+				label: 'Copy Unique Cue ID'
 			}
 		};
 		return(actions);

--- a/feedbacks.js
+++ b/feedbacks.js
@@ -28,7 +28,23 @@ module.exports = {
 					default: ""
 				}],
 				callback: function(feedback, bank) {
-					return { bgcolor: this.cueColors[ (feedback.options.cue).replace(/[^\w\.]/gi,'_') ] };
+					var bg = this.cueColors[ (feedback.options.cue).replace(/[^\w\.]/gi,'_') ]
+					return { bgcolor: (bg || 0) };
+				}.bind(this)
+			},
+			qid_bg: {
+				label: 'Cue ID color for background',
+				description: 'Use the QLab color of the specified cue ID as background',
+				options: [{
+					type: 'textinput',
+					label: 'Cue ID',
+					id: 'cueId',
+					default: this.nextCue
+				}],
+				callback: function(feedback, bank) {
+					var tc = this.wsCues [ (feedback.options.cueId) ];
+					var bg = tc && tc.qColor;
+					return { bgcolor: bg || 0 };
 				}.bind(this)
 			},
 			q_run: {
@@ -47,8 +63,29 @@ module.exports = {
 				},
 				callback: function(feedback, bank) {
 					var opt = feedback.options;
-					var rqID = this.cueByNum[opt.cue.replace(/[^\w\.]/gi,'_')];
-					var rq = (rqID && this.wsCues[rqID]);
+					// var rqID = this.cueByNum[opt.cue.replace(/[^\w\.]/gi,'_')];
+					var rq = this.wsCues[opt.cueID];
+					return (rq && rq.isRunning);
+				}.bind(this)
+			},
+			qid_run: {
+				type: 'boolean',
+				label: 'Indicate Cue ID is running',
+				description: 'Indicate on button when cue ID is running',
+				options: [ {
+					type: 'textinput',
+					label: 'Cue ID',
+					id: 'cueID',
+					default: this.nextCue
+				} ],
+				style: {
+					bgcolor: this.rgb(204,0,204),
+					color: this.rgb(255,255,255),
+				},
+				callback: function(feedback, bank) {
+					var opt = feedback.options;
+					// var rqID = this.cueByNum[opt.cue.replace(/[^\w\.]/gi,'_')];
+					var rq = this.wsCues[opt.cueID];
 					return (rq && rq.isRunning);
 				}.bind(this)
 			},
@@ -117,12 +154,13 @@ module.exports = {
 			},
 			override: {
 				type: 'boolean',
-				label: 'Color for Master Override',
-				description: 'Set Button colors when Override is Active',
+				label: 'Master Override',
+				description: 'Set Button when Override is Active',
 				options: [{
 					type: 'dropdown',
 					label: 'Override',
 					id: 'which',
+					default: this.choices.OVERRIDE[0].id,
 					choices: this.choices.OVERRIDE
 				}],
 				style: {
@@ -134,6 +172,31 @@ module.exports = {
 					var options = feedback.options;
 
 					if (!this.overrides[options.which]) {
+						ret = true;
+					}
+					return ret;
+				}.bind(this)
+			},
+			override_visible: {
+				type: 'boolean',
+				label: 'Override Window Visible',
+				description: 'Set Button when Override Window is visible',
+				options: [{
+					type: 'dropdown',
+					label: 'Override',
+					id: 'which',
+					default: 1,
+					choices: this.choices.ON_OFF
+				}],
+				style: {
+					color: this.rgb(255,255,255),
+					bgcolor: this.rgb(102, 0, 0)
+				},
+				callback: function(feedback, bank) {
+					var ret = false;
+					var options = feedback.options;
+
+					if (this.overrideWindow == 1) {
 						ret = true;
 					}
 					return ret;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"qlab-advance"
 	],
-	"version": "1.3.11",
+	"version": "1.4.0",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",

--- a/presets.js
+++ b/presets.js
@@ -924,10 +924,10 @@ module.exports = {
 			c = this.colors.colorName[i];
 			presets.push({
 				category: 'Edit',
-				label: 'Cue Colour',
+				label: 'Cue Color',
 				bank: {
 					style: 'text',
-					text: 'Cue Colour ' + c.label,
+					text: 'Cue Color ' + c.label,
 					//size: '14',
 					color: textColor(this.colors.colorRGB[c.id]),
 					bgcolor: this.colors.colorRGB[c.id]

--- a/qlabfb.js
+++ b/qlabfb.js
@@ -135,6 +135,7 @@ instance.prototype.resetVars = function (doUpdate) {
 	var self = this;
 	var qName = '';
 	var qNum = '';
+	var qID = '';
 	var cues = self.wsCues;
 
 	// play head info
@@ -150,11 +151,16 @@ instance.prototype.resetVars = function (doUpdate) {
 		Object.keys(cues).forEach(function (cue) {
 			qNum = cues[cue].qNumber.replace(/[^\w\.]/gi,'_');
 			qName = cues[cue].qName;
-			if (qNum != '' && qName != '') {
-				delete self.cueColors[qNum];
-				self.setVariable('q_' + qNum + '_name');
+			qID = cues[cue].uniqueID;
+			if (qName != '') {
+				if (qNum != '') {
+					delete self.cueColors[qNum];
+					self.setVariable('q_' + qNum + '_name');
+				}
 			}
+			self.setVariable('id_' + qID + '_name');
 			self.checkFeedbacks('q_bg');
+			self.checkFeedbacks('qid_bg');
 		});
 	}
 
@@ -222,11 +228,16 @@ instance.prototype.updateQVars = function (q) {
 		}
 	}
 	// set new value
-	if (qNum != '' && q.qName != '' && (q.qName != oqName || qColor != oqColor)) {
-		self.setVariable('q_' + qNum + '_name', q.qName);
-		self.cueColors[qNum] = q.qColor;
-		self.cueByNum[qNum] = q.uniqueID;
+	if (q.qName != '' && (q.qName != oqName || qColor != oqColor)) {
+		if (qNum != '') {
+			self.setVariable('q_' + qNum + '_name', q.qName);
+			self.cueColors[qNum] = q.qColor;
+			self.cueByNum[qNum] = qID;
+		}
+		self.setVariable('id_' + qID + '_name', q.qName);
+
 		self.checkFeedbacks('q_bg');
+		self.checkFeedbacks('qid_bg');
 	}
 };
 
@@ -434,6 +445,7 @@ instance.prototype.prime_vars = function (ws) {
 
 		self.sendOSC("/cueLists", []);
 		self.sendOSC("/auditionWindow",[], true);
+		self.sendOSC("/overrideWindow",[], true);
 		self.sendOSC("/showMode",[]);
 		self.sendOSC("/settings/general/minGoTime");
 		for (var o in self.choices.OVERRIDE) {
@@ -456,8 +468,10 @@ instance.prototype.rePulse = function (ws) {
 	var cl = self.cl;
 	var now = Date.now();
 
-	if (0==(self.pollCount % 10)) {
+	if (0==(self.pollCount % (self.config.useTenths ? 10 : 4))) {
 		self.sendOSC("/auditionWindow", [], true);
+		self.sendOSC("/overrideWindow", [], true);
+
 		self.sendOSC("/cue_id" + (cl ? "/" + cl : "") + "/playheadId",[]);
 
 		if (self.qLab3) {
@@ -483,7 +497,10 @@ instance.prototype.rePulse = function (ws) {
 						delete self.cueColors[qNum];
 						self.setVariable('q_' + qNum + '_name');
 					}
+					self.setVariable('id_' + cues[k].uniqueID + '_name');
 					self.checkFeedbacks('q_bg');
+					self.checkFeedbacks('qid_bg');
+
 				}
 				delete self.requestedCues[k];
 			}
@@ -669,7 +686,9 @@ instance.prototype.updateCues = function (jCue, stat, ql) {
 			i += 1;
 		}
 		self.checkFeedbacks('q_bg');
+		self.checkFeedbacks('qid_bg');
 		self.checkFeedbacks('q_run');
+		self.checkFeedbacks('qid_run');
 		if (dupIds) {
 			self.status(self.STATUS_WARNING, "Multiple cues\nwith the same cue_id");
 		}
@@ -695,6 +714,7 @@ instance.prototype.updateCues = function (jCue, stat, ql) {
 				}
 			}
 			self.checkFeedbacks('q_run');
+			self.checkFeedbacks('qid_run');
 			self.updatePlaying();
 			if ('' == self.cl || self.cueList[self.cl] && self.cueList[self.cl].includes(q.uniqueID)) {
 				if (q.uniqueID == self.nextCue) {
@@ -866,6 +886,7 @@ instance.prototype.readUpdate = function (message) {
 	} else if ((mf.length == 4) && (mf[2] == 'workspace')) {
 		self.sendOSC("/showMode",[]);
 		self.sendOSC("/auditionWindow",[], true);
+		self.sendOSC("/overrideWindow", [], true);
 	} else if (ma.match(/\/settings\/general$/)) {
 		// ug. 8 more bytes and they could have sent the 'new' value :(
 		self.sendOSC("/settings/general/minGoTime");
@@ -921,7 +942,7 @@ instance.prototype.readReply = function (message) {
 			self.debug('cleared stray interval');
 			clearInterval(self.pulse);
 		}
-		self.pulse = setInterval(function() { self.rePulse(ws); }, 100);
+		self.pulse = setInterval(function() { self.rePulse(ws); }, self.config.useTenths ? 100 : 250);
 	} else if (ma.match(/version$/)) {
 		if (j.data != undefined) {
 			self.qLab3 = (j.data.match(/^4\./)==null);
@@ -932,7 +953,7 @@ instance.prototype.readReply = function (message) {
 				self.debug('cleared stray interval');
 				clearInterval(self.pulse);
 			}
-			self.pulse = setInterval(function() { self.rePulse(ws); }, 100);
+			self.pulse = setInterval(function() { self.rePulse(ws); }, self.config.useTenths ? 100 : 250);
 		} else {
 			self.needWorkspace = (!self.qLab3);
 		}
@@ -997,6 +1018,11 @@ instance.prototype.readReply = function (message) {
 			self.auditMode = j.data;
 			self.checkFeedbacks('ws_mode');
 		}
+	} else if (ma.match(/overrideWindow$/)) {
+		if (self.overrideWindow != j.data){
+			self.overrideWindow = j.data;
+			self.checkFeedbacks('override_visible');
+		}
 	} else if (ma.match(/minGoTime$/)) {
 		self.minGo = j.data;
 		self.setVariable('min_go', (Math.round(j.data * 100) / 100).toFixed(2));
@@ -1025,7 +1051,7 @@ instance.prototype.config_fields = function () {
 			id: 'info',
 			width: 12,
 			label: 'Information',
-			value: 'Controls Qlab by <a href="https://figure53.com/" target="_new">Figure 53</a>' +
+			value: 'Controls <a href="https://qlab.app" target="_new">QLab</a> by Figure 53.' +
 				'<br>Feedback and variables require TCP<br>which will increase network traffic.'
 		},
 		{
@@ -1055,7 +1081,7 @@ instance.prototype.config_fields = function () {
 		{
 			type: 'textinput',
 			id: 'passcode',
-			label: 'OSC Pascode',
+			label: 'OSC Passcode',
 			width: 12,
 			tooltip: 'The passcode to controll QLab.\nLeave blank if not needed.'
 		},
@@ -1160,6 +1186,18 @@ instance.prototype.action = function (action) {
 			cmd = '/playhead/' + opt.cue;
 			break;
 
+		case 'copyCueID':
+			self.actions();
+			self.init_feedbacks();
+			break
+		case 'start_id':
+			cmd = '/cue_id/' + opt.cueId + '/start';
+			break;
+
+		case 'goto_id':
+			cmd = '/playheadId/' + opt.cueId;
+			break;
+
 		case 'go':
 			cmd = '/go';
 			break;
@@ -1184,8 +1222,57 @@ instance.prototype.action = function (action) {
 			cmd = '/cue/selected/stop';
 			break;
 
+		case 'copyCueId':
+			self.actions();
+			self.init_feedbacks();
+			break;
+
+		case 'stop_cue':
+			cmd = '/cue/' + opt.cue + '/stop';
+			break;
+
+		case 'stop_id':
+			cmd = '/cue_id/' + opt.cueId + '/stop';
+			break;
+
 		case 'panic':
 			cmd = '/panic';
+			break;
+
+		case 'panicSelected':
+			cmd = '/cue/selected/panic';
+			break;
+
+		case 'panicInTime':
+			cmd = '/cue/selected/panicInTime';
+			arg = {
+				type: typeTime,
+				value: optTime
+			};
+			break;
+
+		case 'panic_cue':
+			cmd = '/cue/' + opt.cue + '/panic';
+			break;
+
+		case 'panicInTime_cue':
+			cmd = '/cue/' + opt.cue + '/panicInTime';
+			arg = {
+				type: typeTime,
+				value: optTime
+			};
+			break;
+
+		case 'panic_id':
+			cmd = '/cue_id/' + opt.cueId + '/panic';
+			break;
+
+		case 'panicInTime_id':
+			cmd = '/cue_id/' + opt.cueId + '/panicInTime';
+			arg = {
+				type: typeTime,
+				value: optTime
+			};
 			break;
 
 		case 'reset':
@@ -1341,6 +1428,13 @@ instance.prototype.action = function (action) {
 			};
 			cmd = '/auditionWindow';
 			break;
+		case 'overrideWindow':
+			arg = {
+				type: 'i',
+				value: setToggle(self.overrideWindow,opt.onOff)
+			};
+			cmd = '/overrideWindow';
+			break;
 		case 'minGo':
 			arg = {
 				type: typeTime,
@@ -1386,11 +1480,11 @@ instance.prototype.action = function (action) {
 		debug("Not connected to", self.config.host);
 	} else if (cmd !== undefined) {
 		debug('sending', cmd, arg, "to", self.config.host);
-		// everything except 'auditionWindow' works on a specific workspace
-		self.sendOSC(cmd, arg, ('/auditionWindow' == cmd));
+		// everything except 'auditionWindow' and 'overrideWindow' works on a specific workspace
+		self.sendOSC(cmd, arg, (['/auditionWindow','/overrideWindow'].includes(cmd)));
 	}
-	// QLab does not send audition window updates
-	if (self.useTCP && cmd == '/auditionWindow') {
+	// QLab does not send window updates so ask for status
+	if (self.useTCP && ['/auditionWindow','/overrideWindow'].includes(cmd)) {
 		self.sendOSC(cmd, [], true);
 		self.sendOSC("/cue/playhead/valuesForKeys",self.qCueRequest);
 	}


### PR DESCRIPTION
Adds new actions and feedback support to use the QLab Unique ID for running and stopping cues.

QLab does not require that every cue has a 'Number'. QLab does create a Unique internal ID for every cue in the workspace that can be used to go to, start, stop, and panic these numberless cues.

This was prompted because I have recently been getting large QLab shows that do not have cue numbers and utilize midi commands to trigger individual group cues.