### PR TITLE
Allow unregistered variables for cues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "figure53-qlab-advance",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"main": "qlabfb.js",
 	"type": "module",
 	"scripts": {

--- a/qlabfb.js
+++ b/qlabfb.js
@@ -32,6 +32,7 @@ class QLabInstance extends InstanceBase {
 	constructor(internal) {
 		super(internal)
 
+		this.instanceOptions.disableVariableValidation = true
 		this.connecting = false
 		this.needPasscode = false
 		this.useTCP = false
@@ -170,6 +171,7 @@ class QLabInstance extends InstanceBase {
 
 		this.setVariableValues(variableValues)
 	}
+
 	updateRunning() {
 		var self = this
 		var tenths = self.config.useTenths ? 0 : 1


### PR DESCRIPTION
The QLab module uses these to provide Cue names for specific cue numbers. Since QLab allows thousands of number, letter, symbol combinations in their cue 'number', it is impossible to pre-register them.