### PR TITLE
Fix UDP mode: parameter error, get Q version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "figure53-qlab-advance",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"main": "qlabfb.js",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Fixed #93, incorrect oscSend paramater when using UDP (non-TCP) mode. 
This would prevent ANY commands working.
Acquire version number from QLab in UDP mode so #92 works in non-TCP mode.