### PR TITLE
Throttle 'wrong' passcode attempts

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -26,15 +26,15 @@ https://github.com/sponsors/istnv
 
 ## Configuration
 
-| Setting               | Description                                                                                                                                                                   |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Target IP**         | Enter the address of the QLab computer. You can enter 127.0.0.1 if Companion is running on the same computer.                                                                 |
-| **Target Port**       | Enter the port number where QLab is listening for OSC messages. This defaults to 53000.                                                                                       |
-| **Use TCP?**          | Check to enable TCP mode. This is required for variables and feedback.                                                                                                        |
-| **Use Tenths**        | If checked, the variable _r_left_ will display 0.1 seconds when less than 5 seconds. If unchecked, the time left will be adjusted by 1 second for a more accurate count-down. |
-| **OSC Passcode**      | Enter a passcode if needed for the QLab workspace. QLab 5 requires a passcode to work reliably from Companion.                                                                |
-| **Workspace**         | Enter the workspace title or ID to control a specific QLab workspace, enter 'default' or leave blank to control active/default workspace.                                     |
-| **Specific Cue List** | Dropdown selection to limit control to a specific cuelist.                                                                                                                    |
+| Setting               | Description                                                                                                                                                                                                              |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Target IP**         | Enter the address of the QLab computer. You can enter 127.0.0.1 if Companion is running on the same computer.                                                                                                            |
+| **Target Port**       | Enter the port number where QLab is listening for OSC messages. This defaults to 53000. Has no effect on QLab4 (or QLab3)                                                                                                                                 |
+| **Use TCP?**          | Check to enable TCP mode. This is required for variables and feedback.                                                                                                                                                   |
+| **Use Tenths**        | If checked, the variable _r_left_ will display 0.1 seconds when less than 5 seconds. If unchecked, the time left will be adjusted by 1 second for a more accurate count-down.                                            |
+| **OSC Passcode**      | Enter a passcode if needed for the QLab workspace. QLab 5 requires a passcode to work reliably from Companion.                                                                                                           |
+| **Workspace**         | Dropdown selection to select a specific Workspace. You can enter 'default' or leave blank to control front-most workspace (if more than one is open) in QLab4. QLab5 commands go to all open workspaces. You can change the IP Control Port too allow multiple workspaces open at once. |
+| **Specific Cue List** | Dropdown selection to limit control to a specific cuelist.                                                                                                                                                               |
 
 ## Actions
 

--- a/config.js
+++ b/config.js
@@ -52,42 +52,48 @@ export function GetConfigFields(self) {
 			width: 12,
 			tooltip: 'The passcode to controll QLab.\nLeave blank if not needed.',
 		},
-		{
-			type: 'textinput',
-			id: 'workspace',
-			label: 'Workspace',
-			width: 12,
-			tooltip: "Enter the name or ID for the workspace.\n Leave blank or enter 'default' for the front Workspace",
-			default: 'default',
-		},
 	]
 
-	if (Object.keys(self.cueList).length > 0) {
-		const oldConfig = self.config
-		const clist = {
-			type: 'dropdown',
-			id: 'cuelist',
-			label: 'Specific Cue List',
-			tooltip: 'Select a specific Cue List for Play Head Variables',
-			width: 12,
-			default: 'default',
-			choices: [
-				{
-					id: 'default',
-					label: 'Default Cue List',
-				},
-			],
-		}
-
-		for (let c in self.cueList) {
-			clist.choices.push({
-				id: c,
-				label: self.wsCues[c].qName,
-			})
-		}
-
-		configs.push(clist)
+	const wlist = {
+		type: 'dropdown',
+		id: 'workspace',
+		label: 'Workspace',
+		width: 12,
+		tooltip: "Select a workspace\nSelect 'default' for the default Workspace",
+		default: 'default',
+		choices: [{ id: 'default', label: 'Default Workspace' }],
 	}
+
+	if (Object.keys(self.wsList).length > 0) {
+		for (let w in self.wsList) {
+			wlist.choices.push({ id: w, label: self.wsList[w].displayName })
+		}
+	}
+
+	configs.push(wlist)
+
+	const clist = {
+		type: 'dropdown',
+		id: 'cuelist',
+		label: 'Specific Cue List',
+		tooltip: 'Select a specific Cue List for Play Head control',
+		width: 12,
+		default: 'default',
+		choices: [
+			{
+				id: 'default',
+				label: 'Default Cue List',
+			},
+		],
+	}
+
+	if (Object.keys(self.cueList).length > 0) {
+		for (let c in self.cueList) {
+			clist.choices.push({ id: c, label: self.wsCues[c].qName })
+		}
+	}
+
+	configs.push(clist)
 
 	return configs
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "figure53-qlab-advance",
-	"version": "2.1.3",
+	"version": "2.2.0",
 	"main": "qlabfb.js",
 	"type": "module",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "figure53-qlab-advance",
-	"version": "2.1.2",
+	"version": "2.1.3",
 	"main": "qlabfb.js",
 	"type": "module",
 	"scripts": {

--- a/workspaces.js
+++ b/workspaces.js
@@ -1,0 +1,26 @@
+import { lastIndexOf } from 'lodash-es'
+import * as Colors from './colors.js'
+
+class Workspace {
+	uniqueID = ''
+	version = ''
+	displayName = 'Untitled Workspace'
+	// QLab 4 only
+	hasPasscode = null
+	// QLab 5 only
+	udpReplyPort = 53001
+	port = 53000
+	connected = false
+
+
+	constructor(j) {
+		if (j) {
+			Object.assign(this, j)
+		}
+		const n = this.displayName
+		this.displayName = n.substring(0,n.lastIndexOf('.'))
+	}
+}
+
+
+export default Workspace


### PR DESCRIPTION
New QLab 5 workspaces have and require a passcode (generated randomly). 
The random passcode is very unlikely to match the passcode configured in Companion.

Previously the module would continue to attempt a connection with a bad passcode and trigger QLab's defense:

From the manual:

> Starting with QLab 5, repeatedly sending this message with incorrect passcodes will introduce a progressively longer delay until the next /connect message will be accepted. This helps to protect against unauthorized users attempting to guess the passcode.

This update records the 'bad' passcode and does not re-attempt to connect more than every 15 seconds, or when all workspaces have closed, or a new passcode is configured.

Note: This was discovered while adding a new Workspace dropdown selection option and created a New workspace to test. The connection rejection would happen fast enough to prevent changing the passcode.