### PR TITLE
Improve elapsed/remaining time display

### DIFF
--- a/cues.js
+++ b/cues.js
@@ -20,6 +20,7 @@ class Cue {
 	autoLoad = false
 	duration = 0
 	pctElapsed = 0
+  elapsed = 0
 	startedAt = -1
 	qColor = 0
 	qColorName = ''
@@ -56,6 +57,7 @@ function JSONtoCue(newCue, j, self) {
 	newCue.duration = j.duration
 	newCue.qParent = j.parent
 	newCue.pctElapsed = j.percentActionElapsed
+  newCue.elapsed = j.actionElapsed
 	if (j.notes) {
 		newCue.Notes = j.notes.slice(0, 20)
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "figure53-qlab-advance",
-	"version": "2.7.3",
+	"version": "2.7.4",
 	"main": "qlabfb.js",
 	"type": "module",
 	"scripts": {

--- a/qlabfb.js
+++ b/qlabfb.js
@@ -253,7 +253,7 @@ class QLabInstance extends InstanceBase {
 		const tenths = this.config.useTenths ? 0 : 1
 		const rc = this.runningCue
 
-		const tElapsed = rc.duration * rc.pctElapsed
+		const tElapsed = rc.elapsed // rc.duration * rc.pctElapsed
 
 		const ehh = pad0(Math.floor(tElapsed / 3600))
 		const emm = pad0(Math.floor(tElapsed / 60) % 60)
@@ -269,7 +269,7 @@ class QLabInstance extends InstanceBase {
 		}
 		eft = eft + ess
 
-		let tLeft = rc.duration * (1 - rc.pctElapsed)
+		let tLeft = rc.duration - tElapsed // * (1 - rc.pctElapsed)
 		if (tLeft > 0) {
 			tLeft += tenths
 		}
@@ -542,7 +542,7 @@ class QLabInstance extends InstanceBase {
 		}
 
 		let rc = this.runningCue
-		if (rc && rc.pctElapsed > 0) {
+		if (rc && rc.elapsed > 0) {
 			if (3 == this.qVer) {
 				this.sendOSC('/runningOrPausedCues', [])
 			} else {


### PR DESCRIPTION
This updates the collection of elapsed time for cues and improves the selection of the 'most likely' running cue.
Time elapsed stays consistent across pause/resume and shows current time when adjusting the load-to-time.