### PR TITLE
feat(feedback): add selected cue's audio output patch feedback

### DIFF
--- a/cues.js
+++ b/cues.js
@@ -31,6 +31,7 @@ class Cue {
 	qParent = ''
 	qList = ''
 	Notes = ''
+	audioPatchName = ''
 
 	constructor(j, self) {
 		if (j != undefined) {
@@ -63,6 +64,7 @@ function JSONtoCue(newCue, j, self) {
   newCue.elapsed = j.actionElapsed
   newCue.preWait = j.preWait
   newCue.postWait = j.postWait
+	newCue.audioPatchName = j.audioOutputPatchName || ''
 	if (j.notes) {
 		newCue.Notes = j.notes.slice(0, 20)
 	}

--- a/feedbacks.js
+++ b/feedbacks.js
@@ -166,6 +166,39 @@ export function compileFeedbackDefinitions(self) {
 				return self.wsCues[cue]?.isSelected
 			},
 		},
+		sel_audio_patch: {
+			type: 'advanced',
+			name: 'Selected Cue Audio Output Patch (text)',
+			description: "Show the selected cue's audio output patch name as button text",
+			options: [],
+			callback: (feedback, context) => {
+				const cue = self.wsCues[self.selectedCues[0]]
+				return { text: cue ? cue.audioPatchName : '' }
+			},
+		},
+		q_audio_patch: {
+			type: 'boolean',
+			name: 'Selected Cue Audio Output Patch Matches',
+			description: "Indicate on button when the selected cue's audio output patch matches the specified name",
+			options: [
+				{
+					type: 'textinput',
+					label: 'Patch Name',
+					id: 'patch',
+					default: '',
+					useVariables: true,
+				},
+			],
+			defaultStyle: {
+				bgcolor: combineRgb(0, 102, 0),
+				color: combineRgb(255, 255, 255),
+			},
+			callback: async (feedback, context) => {
+				const target = await context.parseVariablesInString(feedback.options.patch)
+				const cue = self.wsCues[self.selectedCues[0]]
+				return !!cue && cue.audioPatchName === target
+			},
+		},
 		q_flagged: {
 			type: 'boolean',
 			name: 'Cue is Flagged',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "figure53-qlab-advance",
-	"version": "2.14.1",
+	"version": "2.15.0",
 	"main": "qlabfb.js",
 	"type": "module",
 	"scripts": {

--- a/qlabfb.js
+++ b/qlabfb.js
@@ -19,16 +19,17 @@ class QLabInstance extends InstanceBase {
 			value:
 				'["number","uniqueID","listName","type","mode","isPaused","duration","actionElapsed", "preWait", "postWait","parent",' +
 				'"flagged","notes","autoLoad","colorName","isRunning","isAuditioning","isLoaded","armed",' +
-				'"isBroken","continueMode","percentActionElapsed","cartPosition","infiniteLoop","holdLastFrame"]',
+				'"isBroken","continueMode","percentActionElapsed","cartPosition","infiniteLoop","holdLastFrame","audioOutputPatchName"]',
 		},
 	]
-	fb2check = ['q_run', 'qid_run', 'any_run', 'q_armed', 'q_bg', 'qid_bg', 'q_flagged', 'q_paused']
+	fb2check = ['q_run', 'qid_run', 'any_run', 'q_armed', 'q_bg', 'qid_bg', 'q_flagged', 'q_paused', 'sel_audio_patch', 'q_audio_patch']
 	otherVars = {
 		name: { desc: 'Name', id: 'qName', type: 's' },
 		elapsed: { desc: 'Elapsed time', id: 'elapsed', type: 'n' },
 		id: { desc: 'Unique ID', id: 'uniqueID', type: 's' },
 		num: { desc: 'Cue Number', id: 'qNumber', type: 's' },
 		type: { desc: 'Cue Type', id: 'qType', type: 's' },
+		patch: { desc: 'Audio Output Patch', id: 'audioPatchName', type: 's' },
 	}
 	// list of useful cue types we're interested in
 	qTypes = [
@@ -198,6 +199,7 @@ class QLabInstance extends InstanceBase {
 		const qColor = q.qColor
 		const qElapsed = q.elapsed
 		const qSelected = q.isSelected
+		const qPatch = q.audioPatchName
 		let oqNum = null
 		let oqName = null
 		let oqType = null
@@ -205,6 +207,7 @@ class QLabInstance extends InstanceBase {
 		let oqOrder = -1
 		let oqElapsed = 0
 		let oqSelected = false
+		let oqPatch = ''
 
 		let variableValues = {}
 		let variableDefs = []
@@ -221,6 +224,7 @@ class QLabInstance extends InstanceBase {
 			oqOrder = oq.qOrder
 			oqElapsed = oq.elapsed
 			oqSelected = oq.isSelected
+			oqPatch = oq.audioPatchName
 			if (oqNum != '' && oqNum != qNum) {
 				// cue number changed
 				let vId = `q_${oqNum}_name`
@@ -232,7 +236,7 @@ class QLabInstance extends InstanceBase {
 			}
 		}
 		// set new value
-		if (qID != '' && (qName != oqName || qColor != oqColor || qElapsed != oqElapsed)) {
+		if (qID != '' && (qName != oqName || qColor != oqColor || qElapsed != oqElapsed || qPatch != oqPatch)) {
 			if (q.isPaused) {
 				q.elapsed = Math.max(q.elapsed, oqElapsed ? oqElapsed : 0)
 				q.pctElapsed = Math.max(q.pctElapsed, oq.pctElapsed ? oq.pctElapsed : 0)
@@ -254,6 +258,9 @@ class QLabInstance extends InstanceBase {
 					variableValues[vId] = q[info.id] || (info.type == 's' ? '' : 0) // .qName
 					variableDefs.push({ variableId: vId, name: `${info.desc} of cue ID '${qID}'` })
 				}
+			}
+			if (qID == this.selectedCues[0]) {
+				variableValues.s_patch = qPatch || ''
 			}
 			this.checkFeedbacks(this.fb2check)
 		}
@@ -973,8 +980,9 @@ class QLabInstance extends InstanceBase {
 			s_id: newSel.size == 0 ? '' : this.selectedCues[0],
 			s_count: newSel.size,
 			s_ids: this.selectedCues.join(':'),
+			s_patch: this.wsCues[this.selectedCues[0]]?.audioPatchName || '',
 		})
-		this.checkFeedbacks('q_selected')
+		this.checkFeedbacks('q_selected', 'sel_audio_patch', 'q_audio_patch')
 		//console.log('debug', 'Selected cues updated')
 	}
 

--- a/variables.js
+++ b/variables.js
@@ -65,6 +65,10 @@ export function compileVariableDefinition() {
 			variableId: 's_count',
 		},
 		{
+			name: 'Selected Cue Audio Output Patch (first only)',
+			variableId: 's_patch',
+		},
+		{
 			name: 'Running Cue UniqueID',
 			variableId: 'r_id',
 		},


### PR DESCRIPTION
## Summary
- Adds two new feedbacks scoped to the currently selected cue: a text readout of its audio output patch name, and a boolean feedback that matches against a specified patch name (backed by QLab's `audioOutputPatchName`).
- Adds a new `s_patch` variable (selected cue's audio output patch) plus per-cue-number/ID `patch` variables via the existing `otherVars` mechanism.
- Bumps version to 2.15.0.

## Test plan
- [ ] Load the module in Companion, select an audio cue with an assigned output patch in QLab, and confirm `s_patch` and the new feedbacks reflect the patch name.
- [ ] Select an unpatched cue and confirm the feedback/variable reflect "none".
- [ ] Confirm existing feedbacks/variables are unaffected.